### PR TITLE
Add support for additional configuration items, including multi-freqency support

### DIFF
--- a/rtl_mqtt_bridge.py
+++ b/rtl_mqtt_bridge.py
@@ -183,7 +183,7 @@ def rtl_loop(radio_config: dict, mqtt_handler: HomeNodeMQTT, sys_id: str, sys_mo
 
     # CMD
     cmd = [
-        rtl_433_cmd,  "-s", sample_rate, "-F", "json",
+        rtl_433_cmd, "-d", f":{device_id}", "-s", sample_rate, "-F", "json",
         "-M", "time:iso", "-M", "protocol", "-M", "level",
     ]
 


### PR DESCRIPTION
@jaronmcd 

First of all, thank you for creating this useful application!  I have been desiring something like this for a long time and was excited to see it discussed today on [Hackaday](https://hackaday.com/2025/12/06/bridging-rtl-433-to-home-assistant/). 

I misread how `RTL_CONFIG` works and thought the multi-device example was actually a way to do the frequency hopping option, and once I realized my mistake, I decided to hack in support for that.  This is working well enough on my system jumping between two frequencies, but I only have been working on it for an hour or so, and do not have multiple RTL-SDR devices to test that support.

This adds several items to `RTL_CONFIG`:
* `freq` can be specified as a comma separated list of frequency values
* `hop_interval` maps to the `-H` parameter
* `raw_params` is a generic way of any additional rtl_433 command line parameters
* `rtl_433_cmd` allows you to specify the full path to a rtl_433 executable, if you have a particular version you want to use or it isn't on your path.

Example of a multi-frequency, single device configuration:
`RTL_CONFIG = [{"freq": "433.92M, 915M", "hop_interval": "20", "raw_params": "-Y classic"}]`
