### PR TITLE
Add a "via_device" in the device registry for child devices.

### DIFF
--- a/mqtt_handler.py
+++ b/mqtt_handler.py
@@ -226,7 +226,7 @@ class HomeNodeMQTT:
             }
 
             if device_model != config.BRIDGE_NAME:
-                device_registry["via_device"] = "rtl433_"+config.BRIDGE_NAME+"_"config.BRIDGE_ID
+                device_registry["via_device"] = "rtl433_"+config.BRIDGE_NAME+"_"+config.BRIDGE_ID
                             
             # Inject Firmware Version ONLY for the Bridge itself
             if device_model == config.BRIDGE_NAME:


### PR DESCRIPTION
Added an entry in the device registry for child components that links back the main rtl-haos-bridge device, to basically say "this device is managed by this other device." This is per the documentation on MQTT Autodiscovery here: https://www.home-assistant.io/integrations/sensor.mqtt/