### PR TITLE
inject "via_device" into device_registry

### DIFF
--- a/mqtt_handler.py
+++ b/mqtt_handler.py
@@ -242,6 +242,10 @@ class HomeNodeMQTT:
                 "model": device_model,
                 "name": device_name 
             }
+
+            if device_model != config.BRIDGE_NAME:
+                device_registry["via_device"] = "rtl433_"+config.BRIDGE_NAME+"_"+config.BRIDGE_ID
+            
             if device_model == config.BRIDGE_NAME:
                 device_registry["sw_version"] = self.sw_version
 


### PR DESCRIPTION
Per the documentation for MQTT Discovery, we can add an entry into the device registry called "via_device."  This needs to be the identifier of another device.  The upshot of this is when present and valid, the Home Assistant UI will show a link from child devices to the parent device.  

To that end, on devices where the model name does not equal config.BRIDGE_NAME, mqtt_handler.py will inject this entry with what should be the generated ID number for the bridge, linking devices back to the bridge that generated them.  This can be useful on systems with more than one bridge on the same network to show which bridge generated a device while looking at that device.