### PR TITLE
Fix standalone Docker/Compose builds on Raspberry Pi (ARM) by using multi-arch base

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+# If we're running as a Home Assistant add-on, Supervisor mounts /data/options.json
+# and the HA base images provide with-contenv + bashio.
+if [ -f /data/options.json ] && [ -x /usr/bin/with-contenv ]; then
+  exec /run.sh
+fi
+
+# Standalone Docker mode (Compose, plain Docker, etc.)
+exec /run-standalone.sh

--- a/run-standalone.sh
+++ b/run-standalone.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# Keep version display consistent with add-on mode
+if [ -z "${RTL_HAOS_BUILD:-}" ] && [ -f /app/build.txt ]; then
+  RTL_HAOS_BUILD="$(tr -d '\r\n' < /app/build.txt)"
+  export RTL_HAOS_BUILD
+fi
+
+echo "[STARTUP] RTL-HAOS (standalone)"
+echo "[STARTUP] MQTT Host: ${MQTT_HOST:-localhost}:${MQTT_PORT:-1883}"
+
+exec python3 /app/main.py


### PR DESCRIPTION
Problem
Users running rtl-haos via docker compose on Raspberry Pi (arm64/armv7) hit:
  exec /bin/ash: exec format error
during image build (typically at apk add ...).

Root Cause
The Dockerfile defaulted BUILD_FROM to:
  ghcr.io/home-assistant/amd64-base-python:...
On ARM hosts this pulls an amd64 image; running /bin/ash inside that image fails with “exec format error”.

Solution
Make standalone Docker/Compose builds multi-arch by default, while preserving Home Assistant add-on builds:
- Default BUILD_FROM to multi-arch alpine:3.21 (works on amd64 + arm64 + armv7)
- Add a small entrypoint that detects HA add-on mode and executes /run.sh in that case, otherwise runs the app directly for standalone Docker usage.

Changes
- Dockerfile:
  - Default ARG BUILD_FROM=alpine:3.21 (multi-arch)
  - Ensure python3 is installed in builder + runtime for standalone base images
  - Add /entrypoint.sh and set CMD to it
- entrypoint.sh (new):
  - If /data/options.json exists AND /usr/bin/with-contenv exists (HA add-on base), exec /run.sh
  - Else, exec python3 /app/main.py (standalone mode)

Compatibility / Behavior
- Home Assistant add-on builds remain unchanged:
  - build.yaml continues to pass architecture-specific BUILD_FROM (amd64/aarch64/armv7)
  - entrypoint detects HA environment and runs the existing /run.sh (bashio/s6-overlay path)
- Standalone docker compose installs now build/run on ARM without requiring users to set BUILD_FROM manually.

Testing
- Raspberry Pi (arm64):
  docker compose build --no-cache --pull
  docker compose up
  Expected: no exec format error; container starts.
- amd64 host:
  docker compose build --no-cache --pull
  docker compose up
  Expected: container starts as before.
- HA add-on build (optional sanity):
  Build via existing add-on pipeline; expected: /run.sh used (with-contenv present), no behavior change.

Notes for Reviewers
- This PR intentionally avoids QEMU/binfmt emulation and instead uses native multi-arch images.
- Users can still override BUILD_FROM if they have a specific base image requirement.

