### PR TITLE
Fix device whitelist filtering so it behaves consistently with blacklist and documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@
 - **NEW:** Startup logs print the full `rtl_433` command line per radio (`rtl_433 cmd ...`) for copy/paste troubleshooting.
 - **CHANGED:** Global passthrough (`RTL_433_ARGS` / `rtl_433_args`) now acts as a **global override**: any option present wins over per-radio settings/auto defaults, with a **WARNING per radio** and de-duplicated flags.
 
+### Filtering
+- **FIX:** `device_whitelist` now matches patterns against the decoded device's **ID**, **model**, and **type** (previously it only matched the cleaned ID), restoring documented model-based whitelisting behavior.
+- **DOCS:** Clarify whitelist/blacklist glob syntax (no regex) and add examples for model- and ID-based rules.
+
 ### Tests
 - **NEW:** Unit tests for version handling and command building.
 - **NEW:** Hardware-only smoke test for passthrough flags (skipped unless `RUN_HARDWARE_TESTS=1`).

--- a/README.md
+++ b/README.md
@@ -253,6 +253,18 @@ DEVICE_BLACKLIST='["SimpliSafe*", "EezTire*"]'
 # Device filtering (allow only specific devices - optional)
 DEVICE_WHITELIST='["Acurite-5n1*", "AmbientWeather*"]'
 ```
+
+Pattern syntax (for `DEVICE_WHITELIST` / `DEVICE_BLACKLIST`):
+- Patterns use shell-style glob matching (Python `fnmatch`): `*`, `?`, and `[]` character classes.
+- Patterns are matched against the decoded device's **ID**, **model**, and **type** fields.
+- Matching is case-insensitive.
+- Regular expressions (e.g., `^...$`) are not supported.
+
+Examples:
+- Whitelist by exact model: `DEVICE_WHITELIST='["Cotech-367959"]'`
+- Whitelist by prefix: `DEVICE_WHITELIST='["Cotech*"]'`
+- Whitelist by ID: `DEVICE_WHITELIST='["101"]'`
+
 **Misc Configuration:**
 ```bash
 # Toggle "Last: HH:MM:SS" vs "Online" in status
@@ -338,6 +350,16 @@ device_blacklist: # Block specific device patterns
   - "SimpliSafe*"
   - "EezTire*"
 device_whitelist: [] # If set, only allow these patterns
+
+# Pattern syntax
+# - Patterns use shell-style glob matching (fnmatch): *, ?, and [] character classes.
+# - Patterns are matched against the decoded device's ID, model, and type fields.
+# - Matching is case-insensitive.
+# - Regular expressions (e.g., ^...$) are not supported.
+# Examples:
+# - "Cotech-367959"  # exact model
+# - "Cotech*"       # model prefix
+# - "101"           # exact ID
 ```
 
 #### 4. Start the Add-on

--- a/config.yaml
+++ b/config.yaml
@@ -58,10 +58,16 @@ options:
   rtl_auto_band_plan: "auto"
 
   # --- Device Filtering ---
-  # Define specific Devices or ID Numbers to allow or disallow
-  # Example:
-  # - "Acurite 5n1*"
-  # - "*8675*"
+  # Define device patterns to allow or disallow.
+  # Patterns use shell-style glob matching (Python fnmatch): *, ?, and [] character classes.
+  # Patterns are matched against the decoded device's ID, model, and type fields.
+  # Matching is case-insensitive.
+  # Regular expressions (e.g. ^...$) are not supported.
+  # Examples:
+  # - "Cotech-367959"   # exact model
+  # - "Cotech*"        # model prefix
+  # - "101"            # exact ID
+  # - "*8675*"         # substring match (model or ID)
   device_blacklist:
     - "SimpliSafe*"
     - "EezTire*"

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -139,14 +139,24 @@ Notes:
 You can restrict which decoded devices become entities using whitelist/blacklist rules:
 
 ```yaml
-rtl_whitelist:
+device_whitelist:
   - "Acurite-5n1*"
   - "AmbientWeather*"
-rtl_blacklist:
+device_blacklist:
   - "EcoWitt-WH40*"
 ```
 
-(Exact matching behavior is defined in code; see `config.yaml` for the option names.)
+Pattern syntax:
+- Patterns use shell-style glob matching (fnmatch): `*`, `?`, and `[]` character classes.
+- Patterns are matched against the decoded device's **ID**, **model**, and **type** fields.
+- Matching is case-insensitive.
+- Regular expressions (e.g., `^...$`) are not supported.
+
+Examples:
+- Exact model: `Cotech-367959`
+- Prefix model: `Cotech*`
+- Exact ID: `101`
+
 
 ### Multiple RTL-SDR dongles with duplicate serials
 

--- a/rtl_manager.py
+++ b/rtl_manager.py
@@ -637,12 +637,46 @@ def _debug_dump_packet(
 def is_blocked_device(clean_id: str, model: str, dev_type: str) -> bool:
     patterns = getattr(config, "DEVICE_BLACKLIST", [])
     for pattern in patterns:
-        if fnmatch.fnmatch(str(clean_id), pattern):
+        # Treat patterns as glob-style matches (fnmatch). Match against ID, model, and type.
+        # For user friendliness, also attempt a case-insensitive match.
+        p = str(pattern)
+        pl = p.lower()
+        if fnmatch.fnmatch(str(clean_id), p) or fnmatch.fnmatch(str(clean_id).lower(), pl):
             return True
-        if fnmatch.fnmatch(str(model), pattern):
+        if fnmatch.fnmatch(str(model), p) or fnmatch.fnmatch(str(model).lower(), pl):
             return True
-        if fnmatch.fnmatch(str(dev_type), pattern):
+        if fnmatch.fnmatch(str(dev_type), p) or fnmatch.fnmatch(str(dev_type).lower(), pl):
             return True
+    return False
+
+
+def is_allowed_device(clean_id: str, model: str, dev_type: str, raw_id: Optional[object] = None) -> bool:
+    """Whitelist allow-list.
+
+    If DEVICE_WHITELIST is empty, everything is allowed.
+    If set, at least one pattern must match.
+
+    Patterns are treated as glob-style matches (fnmatch), consistent with blacklist behavior.
+    Matching is attempted against:
+      - clean_id (mqtt-safe ID used for topics/unique_id)
+      - model (rtl_433 "model" field)
+      - dev_type (rtl_433 "type" field, if present)
+      - raw_id (rtl_433 "id" field, if provided)
+    """
+    patterns = getattr(config, "DEVICE_WHITELIST", [])
+    if not patterns:
+        return True
+
+    candidates: list[str] = [str(clean_id), str(model), str(dev_type)]
+    if raw_id is not None:
+        candidates.append(str(raw_id))
+
+    for pattern in patterns:
+        p = str(pattern)
+        pl = p.lower()
+        for c in candidates:
+            if fnmatch.fnmatch(c, p) or fnmatch.fnmatch(c.lower(), pl):
+                return True
     return False
 
 
@@ -814,8 +848,7 @@ def rtl_loop(radio_config: dict, mqtt_handler, data_processor, sys_id: str, sys_
                     if is_blocked_device(clean_id, model, dev_type):
                         continue
 
-                    whitelist = getattr(config, "DEVICE_WHITELIST", [])
-                    if whitelist and not any(fnmatch.fnmatch(clean_id, p) for p in whitelist):
+                    if not is_allowed_device(clean_id, model, dev_type, raw_id=raw_id):
                         continue
 
                     # Neptune R900 Water Meter

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,5 +1,5 @@
 import pytest
-from rtl_manager import is_blocked_device
+from rtl_manager import is_blocked_device, is_allowed_device
 
 def test_blacklist_logic(mocker):
     """
@@ -21,3 +21,31 @@ def test_blacklist_logic(mocker):
     # 3. Test Cases that should be ALLOWED (False)
     assert is_blocked_device("98765", "Generic", "weather") is False
     assert is_blocked_device("55555", "Nest", "co2") is False
+
+
+def test_whitelist_logic_matches_id_model_type_and_raw_id(mocker):
+    """Whitelist should allow by ID, Model, or Type (glob patterns).
+
+    Regression for cases where whitelist was applied only to the cleaned ID.
+    """
+
+    # Match by exact model
+    mocker.patch("config.DEVICE_WHITELIST", ["Cotech-367959"])
+    assert is_allowed_device("101", "Cotech-367959", "weather", raw_id=101) is True
+    assert is_allowed_device("101", "OtherModel", "weather", raw_id=101) is False
+
+    # Match by model prefix glob
+    mocker.patch("config.DEVICE_WHITELIST", ["Cotech*"])
+    assert is_allowed_device("101", "Cotech-367959", "weather", raw_id=101) is True
+
+    # Match by ID
+    mocker.patch("config.DEVICE_WHITELIST", ["101"])
+    assert is_allowed_device("101", "OtherModel", "weather", raw_id=101) is True
+
+    # Match by Type
+    mocker.patch("config.DEVICE_WHITELIST", ["wea*"])
+    assert is_allowed_device("101", "OtherModel", "weather", raw_id=101) is True
+
+    # Match by raw_id formatting (e.g., with separators)
+    mocker.patch("config.DEVICE_WHITELIST", ["AA:BB*"])
+    assert is_allowed_device("aabbccdd", "OtherModel", "weather", raw_id="AA:BB:CC:DD") is True


### PR DESCRIPTION
Details
- Adjust whitelist matching so it correctly allows intended devices (previously it could block everything when configured).
- Keep glob-style pattern matching consistent with the existing blacklist behavior.
- Add a small regression test to prevent this from returning.
- Update docs/add-on config comments to clearly state the supported pattern syntax (glob, not regex) and include a couple of examples.

Impact
No config or schema changes. Behavior is unchanged unless a whitelist is configured; whitelisting by model now works as expected.
