### PR TITLE
Remove asterisk* from non-required field "Gas Unit"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -74,11 +74,11 @@ options:
   device_whitelist: []
 
 schema:
-  gas_unit: str
   mqtt_host: str
   mqtt_port: port
   mqtt_user: str
   mqtt_pass: password
+  gas_unit: str?
   bridge_id: str
   bridge_name: str
   rtl_expire_after: int


### PR DESCRIPTION
Gas Unit falls back to "ft3" if unspecified so it's not required: https://github.com/jaronmcd/rtl-haos/blob/f4219363bfe3ca8b5dc114b8589338afedde84c0/mqtt_handler.py#L201

Further, move it down a little bit. Gas Unit isn't the most important setting here.

First commit towards #90. Mostly just testing to open a conversation on if upstream wants this; if so I can update the rest of the optional fields to remove their asterisks too.