### PR TITLE
Add a description (translation) for gas_unit

### DIFF
--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -1,4 +1,9 @@
 configuration:
+  gas_unit:
+    name: Gas Unit
+    description: >-
+      Unit for gas utility readings. Use 'ft3' (cubic feet) or 'ccf' (hundred cubic feet).
+      Defaults to 'ft3' if left empty.
   mqtt_host:
     name: MQTT Host
     description: >-


### PR DESCRIPTION
This will explain to the user what the field means (I was a bit confused what it meant before I looked at the code).