### PR TITLE
feat: add binary_sensor support for security fields

### DIFF
--- a/config.py
+++ b/config.py
@@ -189,6 +189,13 @@ class Settings(BaseSettings):
             "volume_ft3",
             "volume_m3",
             "moisture",
+            # Binary sensors (security)
+            "tamper",
+            "alarm",
+            "contact_open",
+            "reed_open",
+            "detect_wet",
+            "ext_power",
         ]
     )
 

--- a/field_meta.py
+++ b/field_meta.py
@@ -158,6 +158,16 @@ FIELD_META = {
     "current_A":           ("A", "current", "mdi:current-ac", "Current"),
 
 
+    # --- Security / Binary Sensors ---
+    # These fields are published as binary_sensors with appropriate device classes.
+    # The actual binary_sensor logic is in mqtt_handler.py BINARY_SENSOR_FIELDS.
+    "tamper":               (None, "tamper", "mdi:alert-circle", "Tamper"),
+    "alarm":                (None, "safety", "mdi:alarm-light", "Alarm"),
+    "contact_open":         (None, "door", "mdi:door", "Door"),
+    "reed_open":            (None, "door", "mdi:door", "Door"),
+    "detect_wet":           (None, "moisture", "mdi:water-alert", "Water Detected"),
+    "ext_power":            (None, "plug", "mdi:power-plug", "External Power"),
+
     # --- Battery ---
     # Many decoders emit battery_ok where 1/True means battery is OK and 0/False
     # means battery is LOW. We publish this as a binary sensor (device_class: battery)

--- a/mqtt_handler.py
+++ b/mqtt_handler.py
@@ -138,6 +138,22 @@ def _parse_boolish(value):
             return False
     return None
 
+
+# Binary sensor field definitions.
+# Format: field_name -> (device_class, friendly_name, invert)
+# - device_class: Home Assistant binary_sensor device_class
+# - friendly_name: Display name for the entity
+# - invert: If True, ON means the condition is NOT present (like battery_ok)
+#           If False, ON means the condition IS present (like tamper=1 means tampered)
+BINARY_SENSOR_FIELDS = {
+    "tamper": ("tamper", "Tamper", False),
+    "alarm": ("safety", "Alarm", False),
+    "contact_open": ("door", "Door", False),  # 1 = open
+    "reed_open": ("door", "Door", False),  # 1 = open
+    "detect_wet": ("moisture", "Water Detected", False),
+    "ext_power": ("plug", "External Power", False),
+}
+
 class HomeNodeMQTT:
     def __init__(self, version="Unknown"):
         self.sw_version = version
@@ -672,6 +688,29 @@ class HomeNodeMQTT:
 
             if friendly_name is None:
                 friendly_name = "Battery Low"
+
+        # Handle other binary sensor fields (tamper, alarm, contact_open, etc.)
+        elif field in BINARY_SENSOR_FIELDS:
+            parsed = _parse_boolish(value)
+            if parsed is None:
+                return
+
+            device_class, default_friendly, invert = BINARY_SENSOR_FIELDS[field]
+
+            # Determine ON/OFF state
+            # invert=False: 1/True -> ON (condition present)
+            # invert=True: 1/True -> OFF (condition NOT present, like battery_ok)
+            if invert:
+                is_on = not parsed
+            else:
+                is_on = parsed
+
+            domain = "binary_sensor"
+            out_value = "ON" if is_on else "OFF"
+            extra_payload = {"payload_on": "ON", "payload_off": "OFF", "device_class": device_class}
+
+            if friendly_name is None:
+                friendly_name = default_friendly
 
         discovery_published_now = self._publish_discovery(
             field,


### PR DESCRIPTION
## Summary
- Add `BINARY_SENSOR_FIELDS` dict for DSC/Honeywell security sensors
- Support fields: tamper, alarm, contact_open, reed_open, detect_wet, ext_power
- Proper Home Assistant binary_sensor entities with correct device classes

## Sensors Supported
- DSC Security (WS4945, DW10, etc.)
- Honeywell 5800 series
- Similar 345MHz security sensors

## Test plan
- [ ] Verify DSC door/window sensors show as binary_sensor entities
- [ ] Verify tamper detection works correctly
- [ ] Verify battery_ok still works (separate handling)