### PR TITLE
feat: add weather station field support (Acurite/LaCrosse)

### DIFF
--- a/field_meta.py
+++ b/field_meta.py
@@ -87,12 +87,18 @@ FIELD_META = {
     "wind_max_mi_h":       ("mph", "wind_speed", "mdi:weather-windy-variant", "Wind Gust"),
     "wind_dir_deg":         ("°", "wind_direction", "mdi:compass", "Wind Direction"),
     "wind_dir":             ("°", "wind_direction", "mdi:compass", "Wind Direction"),
+    "wind_dev_deg":         ("°", "none", "mdi:compass-rose", "Wind Deviation"),
 
     # --- Rain ---
     "rain_mm":              ("mm", "precipitation", "mdi:weather-rainy", "Rain Total"),
     "rain_in":              ("in", "precipitation", "mdi:weather-rainy", "Rain Total"),
     "rain_rate_mm_h":       ("mm/h", "precipitation_intensity", "mdi:weather-pouring", "Rain Rate"),
     "rain_rate_in_h":       ("in/h", "precipitation_intensity", "mdi:weather-pouring", "Rain Rate"),
+    "rain2_mm":             ("mm", "precipitation", "mdi:weather-rainy", "Rain Total 2"),
+    "rain_raw":             ("count", "none", "mdi:weather-rainy", "Rain Raw Count"),
+    "rain":                 ("count", "none", "mdi:weather-rainy", "Rain Count"),
+    "rain1":                ("count", "none", "mdi:weather-rainy", "Rain Count 1"),
+    "rain2":                ("count", "none", "mdi:weather-rainy", "Rain Count 2"),
 
     # --- Light ---
     "lux":                  ("lx", "illuminance", "mdi:brightness-5", "Light Level"),
@@ -101,6 +107,7 @@ FIELD_META = {
     "full_lux":             ("cnt", "none", "mdi:brightness-7", "Raw Full Spectrum"),
     "ir_lux":               ("cnt", "none", "mdi:cctv", "Raw IR"),
     "uv":                   ("UV Index", "none", "mdi:sunglasses", "UV Index"),
+    "exposure_mins":        ("min", "duration", "mdi:sun-clock", "UV Exposure Time"),
 
     # --- Lightning ---
     "strikes":              ("count", "none", "mdi:flash", "Lightning Strikes"),
@@ -144,6 +151,9 @@ FIELD_META = {
     "sequence_num":         (None, "none", "mdi:counter", "Sequence"),
     "message_type":         (None, "none", "mdi:message-text", "Message Type"),
     "exception":            (None, "none", "mdi:alert-circle", "Exception"),
+    "seq":                  (None, "none", "mdi:counter", "Sequence"),
+    "startup":              (None, "none", "mdi:power", "Startup"),
+    "test":                 (None, "none", "mdi:test-tube", "Test Mode"),
 
     # --- Depth / Level ---
     "depth_cm":             ("cm", "distance", "mdi:arrow-collapse-down", "Depth"),
@@ -187,6 +197,7 @@ FIELD_META = {
     "battery_mV":          ("mV", "voltage", "mdi:battery", "Battery Voltage"),
     "battery_low":         (None, "none", "mdi:battery-alert", "Battery Low (Raw)"),
     "battery_raw":         ("cnt", "none", "mdi:battery", "Battery Raw"),
+    "newbattery":          (None, "none", "mdi:battery-plus", "New Battery"),
 
 }
 

--- a/field_meta.py
+++ b/field_meta.py
@@ -43,6 +43,7 @@ FIELD_META = {
     "temperature_4_C":     ("°C", "temperature", "mdi:thermometer", "Temperature 4 (C)"),
     "temperature_1_F":     ("°F", "temperature", "mdi:thermometer", "Temperature 1"),
     "temperature_2_F":     ("°F", "temperature", "mdi:thermometer", "Temperature 2"),
+    "temperature_2":       ("°F", "temperature", "mdi:thermometer", "Temperature 2"),
     "dew_point":            ("°F", "temperature", "mdi:weather-fog", "Dew Point"),
 
     # --- Humidity ---
@@ -72,8 +73,15 @@ FIELD_META = {
     "wind_avg_km_h":        ("km/h", "wind_speed", "mdi:weather-windy", "Wind Speed"),
     "wind_avg_mi_h":        ("mph", "wind_speed", "mdi:weather-windy", "Wind Speed"),
     "wind_avg_m_s":        ("m/s", "wind_speed", "mdi:weather-windy", "Wind Speed"),
+    "wind_speed":           ("km/h", "wind_speed", "mdi:weather-windy", "Wind Speed"),
+    "wind_speed_km_h":      ("km/h", "wind_speed", "mdi:weather-windy", "Wind Speed"),
+    "wind_speed_m_s":       ("m/s", "wind_speed", "mdi:weather-windy", "Wind Speed"),
+    "wind_speed_mi_h":      ("mph", "wind_speed", "mdi:weather-windy", "Wind Speed"),
     "wind_gust_km_h":       ("km/h", "wind_speed", "mdi:weather-windy-variant", "Wind Gust"),
     "wind_gust_mi_h":       ("mph", "wind_speed", "mdi:weather-windy-variant", "Wind Gust"),
+    "wind_gust_m_s":        ("m/s", "wind_speed", "mdi:weather-windy-variant", "Wind Gust"),
+    "gust_speed_km_h":      ("km/h", "wind_speed", "mdi:weather-windy-variant", "Wind Gust"),
+    "gust_speed_m_s":       ("m/s", "wind_speed", "mdi:weather-windy-variant", "Wind Gust"),
     "wind_max_m_s":        ("m/s", "wind_speed", "mdi:weather-windy-variant", "Wind Gust"),
     "wind_max_km_h":       ("km/h", "wind_speed", "mdi:weather-windy-variant", "Wind Gust"),
     "wind_max_mi_h":       ("mph", "wind_speed", "mdi:weather-windy-variant", "Wind Gust"),
@@ -98,7 +106,10 @@ FIELD_META = {
     "strikes":              ("count", "none", "mdi:flash", "Lightning Strikes"),
     "strike_distance":      ("km", "distance", "mdi:flash-alert", "Storm Distance"),
     "storm_dist":           ("km", "distance", "mdi:flash-alert", "Storm Distance"),
+    "storm_distance":       ("km", "distance", "mdi:flash-alert", "Storm Distance"),
+    "storm_dist_km":        ("km", "distance", "mdi:flash-alert", "Storm Distance"),
     "strike_count":         (None, "none", "mdi:lightning-bolt", "Strike Count"),
+    "active":               (None, "none", "mdi:flash", "Lightning Active"),
 
     # --- Soil Moisture ---
     "moisture":            ("%", "moisture", "mdi:water-percent", "Soil Moisture"),
@@ -130,7 +141,15 @@ FIELD_META = {
     "mic":                  ("", "none", "mdi:check-network", "Integrity Check"),
     "radio_status":         ("", "none", "mdi:radio-tower", "Radio Status"),
     "rfi":                  (None, "none", "mdi:radio-tower", "RFI"),
-    
+    "sequence_num":         (None, "none", "mdi:counter", "Sequence"),
+    "message_type":         (None, "none", "mdi:message-text", "Message Type"),
+    "exception":            (None, "none", "mdi:alert-circle", "Exception"),
+
+    # --- Depth / Level ---
+    "depth_cm":             ("cm", "distance", "mdi:arrow-collapse-down", "Depth"),
+    "depth_mm":             ("mm", "distance", "mdi:arrow-collapse-down", "Depth"),
+    "depth_in":             ("in", "distance", "mdi:arrow-collapse-down", "Depth"),
+
     # --- Utility Meters ---
     "Consumption":          ("ft³", "gas", "mdi:fire", "Gas Usage"),
     "consumption":          ("ft³", "gas", "mdi:fire", "Gas Usage"),


### PR DESCRIPTION
## Summary
Add comprehensive field metadata for weather station sensors.

## Sensors Supported

### Acurite/LaCrosse Weather Stations
- Additional wind fields: wind_speed variants, gust_speed variants, wind_dev_deg
- Storm distance variants: storm_distance, storm_dist_km
- Depth/level sensors: depth_cm, depth_mm, depth_in
- Temperature variants: temperature_2
- Lightning: active field

### LaCrosse Specific (TX29, TX35, WS7000, R1, WR1)
- Rain fields: rain2_mm, rain_raw, rain, rain1, rain2
- Wind: wind_dev_deg (deviation)
- UV: exposure_mins
- Protocol: seq, startup, test
- Battery: newbattery

## Test plan
- [ ] Verify weather station fields appear correctly
- [ ] Verify rain gauge raw counts work
- [ ] Verify wind deviation displays