### PR TITLE
feat: add Fineoffset/Ecowitt sensor field support

### DIFF
--- a/field_meta.py
+++ b/field_meta.py
@@ -96,6 +96,8 @@ FIELD_META = {
     "ir_lux":               ("cnt", "none", "mdi:cctv", "Raw IR"),
     "uv":                   ("UV Index", "none", "mdi:sunglasses", "UV Index"),
     "wm":                   ("W/m²", "irradiance", "mdi:white-balance-sunny", "Solar Radiation"),
+    "uv_sensor_id":         (None, "none", "mdi:identifier", "UV Sensor ID"),
+    "uv_status":            (None, "none", "mdi:check-circle", "UV Sensor Status"),
 
     # --- Lightning ---
     "strikes":              ("count", "none", "mdi:flash", "Lightning Strikes"),
@@ -140,6 +142,9 @@ FIELD_META = {
     "sensitivity":          (None, "none", "mdi:tune", "Sensitivity"),
     "raw_value":            (None, "none", "mdi:numeric", "Raw Value"),
     "ad_raw":               (None, "none", "mdi:numeric", "ADC Raw"),
+    "boost":                (None, "none", "mdi:signal-cellular-3", "Boost Mode"),
+    "msg_type":             (None, "none", "mdi:message-text", "Message Type"),
+    "data":                 (None, "none", "mdi:code-braces", "Extra Data"),
 
     # --- Utility Meters ---
     "Consumption":          ("ft³", "gas", "mdi:fire", "Gas Usage"),

--- a/field_meta.py
+++ b/field_meta.py
@@ -85,19 +85,23 @@ FIELD_META = {
     "rain_in":              ("in", "precipitation", "mdi:weather-rainy", "Rain Total"),
     "rain_rate_mm_h":       ("mm/h", "precipitation_intensity", "mdi:weather-pouring", "Rain Rate"),
     "rain_rate_in_h":       ("in/h", "precipitation_intensity", "mdi:weather-pouring", "Rain Rate"),
+    "rain_start":           (None, "none", "mdi:weather-rainy", "Rain Detected"),
 
     # --- Light ---
     "lux":                  ("lx", "illuminance", "mdi:brightness-5", "Light Level"),
     "light_lux":           ("lx", "illuminance", "mdi:brightness-5", "Light Level"),
     "uvi":                 ("UV Index", "none", "mdi:sunglasses", "UV Index"),
+    "uv_index":            ("UV Index", "none", "mdi:sunglasses", "UV Index"),
     "full_lux":             ("cnt", "none", "mdi:brightness-7", "Raw Full Spectrum"),
     "ir_lux":               ("cnt", "none", "mdi:cctv", "Raw IR"),
     "uv":                   ("UV Index", "none", "mdi:sunglasses", "UV Index"),
+    "wm":                   ("W/m²", "irradiance", "mdi:white-balance-sunny", "Solar Radiation"),
 
     # --- Lightning ---
     "strikes":              ("count", "none", "mdi:flash", "Lightning Strikes"),
     "strike_distance":      ("km", "distance", "mdi:flash-alert", "Storm Distance"),
     "storm_dist":           ("km", "distance", "mdi:flash-alert", "Storm Distance"),
+    "storm_dist_km":        ("km", "distance", "mdi:flash-alert", "Storm Distance"),
     "strike_count":         (None, "none", "mdi:lightning-bolt", "Strike Count"),
 
     # --- Soil Moisture ---
@@ -130,7 +134,13 @@ FIELD_META = {
     "mic":                  ("", "none", "mdi:check-network", "Integrity Check"),
     "radio_status":         ("", "none", "mdi:radio-tower", "Radio Status"),
     "rfi":                  (None, "none", "mdi:radio-tower", "RFI"),
-    
+    "radio_clock":          (None, "timestamp", "mdi:radio-tower", "Radio Clock"),
+    "signal":               (None, "none", "mdi:signal", "Signal Type"),
+    "firmware":             (None, "none", "mdi:chip", "Firmware"),
+    "sensitivity":          (None, "none", "mdi:tune", "Sensitivity"),
+    "raw_value":            (None, "none", "mdi:numeric", "Raw Value"),
+    "ad_raw":               (None, "none", "mdi:numeric", "ADC Raw"),
+
     # --- Utility Meters ---
     "Consumption":          ("ft³", "gas", "mdi:fire", "Gas Usage"),
     "consumption":          ("ft³", "gas", "mdi:fire", "Gas Usage"),
@@ -168,6 +178,8 @@ FIELD_META = {
     "battery_mV":          ("mV", "voltage", "mdi:battery", "Battery Voltage"),
     "battery_low":         (None, "none", "mdi:battery-alert", "Battery Low (Raw)"),
     "battery_raw":         ("cnt", "none", "mdi:battery", "Battery Raw"),
+    "battery_level":       (None, "none", "mdi:battery", "Battery Level"),
+    "supercap_V":          ("V", "voltage", "mdi:solar-power", "Supercapacitor"),
 
 }
 


### PR DESCRIPTION
## Summary
Add comprehensive field metadata for Fineoffset/Ecowitt sensors.

## Sensors Supported
- **WH65B/WH40**: rain_start (rain detection)
- **WS90/WS85**: Solar wind sensors
  - wm (solar irradiance W/m²)
  - supercap_V (supercapacitor voltage)
  - uv_index, uv_sensor_id, uv_status
  - radio_clock, signal, firmware
  - boost, sensitivity
- **WH57**: Lightning detector
  - storm_dist_km
- **General**: battery_level, raw_value, ad_raw, msg_type, data

## Fields Added (18 total)
- rain_start, uv_index, wm, storm_dist_km
- radio_clock, signal, firmware, sensitivity, raw_value, ad_raw
- battery_level, supercap_V
- uv_sensor_id, uv_status, boost, msg_type, data

## Test plan
- [ ] Verify WS90 solar fields appear
- [ ] Verify supercapacitor voltage displays
- [ ] Verify UV sensor diagnostics work