### PR TITLE
feat: add optional timestamp sensor support

### DIFF
--- a/config.py
+++ b/config.py
@@ -140,7 +140,13 @@ class Settings(BaseSettings):
     )
 
     # --- Device filtering ---
+    # Note: "time" is included by default. To publish timestamps, set rtl_publish_timestamps=True
+    # and ensure rtl_433 outputs time data (add "-M time" or "-M utc" to RTL_433_ARGS).
     skip_keys: list[str] = Field(default_factory=lambda: ["time", "protocol", "mod", "id"])
+
+    # If True, publish the "time" field from rtl_433 as a timestamp sensor.
+    # Requires rtl_433 to output time metadata (e.g., RTL_433_ARGS includes "-M time" or "-M utc").
+    rtl_publish_timestamps: bool = Field(default=False)
     device_blacklist: list[str] = Field(default_factory=lambda: ["SimpliSafe*", "EezTire*"])
     device_whitelist: list[str] = Field(default_factory=list)
 
@@ -253,7 +259,13 @@ RTL_AUTO_HOPPER_FREQS = settings.rtl_auto_hopper_freqs
 RTL_AUTO_HOPPER_HOP_INTERVAL = settings.rtl_auto_hopper_hop_interval
 RTL_AUTO_HOPPER_RATE = settings.rtl_auto_hopper_rate
 
-SKIP_KEYS = settings.skip_keys
+# Remove "time" from skip_keys if rtl_publish_timestamps is enabled
+_skip_keys = list(settings.skip_keys)
+if settings.rtl_publish_timestamps and "time" in _skip_keys:
+    _skip_keys.remove("time")
+SKIP_KEYS = _skip_keys
+
+RTL_PUBLISH_TIMESTAMPS = settings.rtl_publish_timestamps
 DEVICE_BLACKLIST = settings.device_blacklist
 DEVICE_WHITELIST = settings.device_whitelist
 MAIN_SENSORS = settings.main_sensors

--- a/field_meta.py
+++ b/field_meta.py
@@ -130,7 +130,12 @@ FIELD_META = {
     "mic":                  ("", "none", "mdi:check-network", "Integrity Check"),
     "radio_status":         ("", "none", "mdi:radio-tower", "Radio Status"),
     "rfi":                  (None, "none", "mdi:radio-tower", "RFI"),
-    
+
+    # --- Timestamp ---
+    # rtl_433 outputs a "time" field when run with -M time or -M utc.
+    # This is useful to see when a device last transmitted, even if values didn't change.
+    "time":                 (None, "timestamp", "mdi:clock-in", "Last Seen"),
+
     # --- Utility Meters ---
     "Consumption":          ("ft³", "gas", "mdi:fire", "Gas Usage"),
     "consumption":          ("ft³", "gas", "mdi:fire", "Gas Usage"),

--- a/rtl_manager.py
+++ b/rtl_manager.py
@@ -205,6 +205,9 @@ def _ensure_rtl433_outputs(cmd: list[str], *, radio_label: str, global_map: dict
     # Default metadata: add '-M level' if user didn't specify any -M
     if "-M" not in opt_map:
         cmd.extend(["-M", "level"])
+        # Also add '-M time' if rtl_publish_timestamps is enabled
+        if getattr(config, "RTL_PUBLISH_TIMESTAMPS", False):
+            cmd.extend(["-M", "time"])
 
     return cmd
 


### PR DESCRIPTION
## Summary
Add optional timestamp sensor support for rtl_433 time metadata.

## Changes
- Add `rtl_publish_timestamps` config option (default: false)
- Remove "time" from skip_keys when enabled
- Add `-M time` flag to rtl_433 when enabled
- Add `time` field metadata

## Configuration
```yaml
rtl_publish_timestamps: true
```

When enabled, each device will have a "Last Seen" timestamp sensor showing when it last transmitted.

## Test plan
- [ ] Verify timestamps disabled by default
- [ ] Enable and verify time field appears
- [ ] Verify rtl_433 receives -M time flag