### PR TITLE
feat: add raw_msg field for protocol analysis

### DIFF
--- a/field_meta.py
+++ b/field_meta.py
@@ -130,7 +130,11 @@ FIELD_META = {
     "mic":                  ("", "none", "mdi:check-network", "Integrity Check"),
     "radio_status":         ("", "none", "mdi:radio-tower", "Radio Status"),
     "rfi":                  (None, "none", "mdi:radio-tower", "RFI"),
-    
+
+    # --- Raw Data ---
+    # Raw hex message from rtl_433, useful for debugging or protocol analysis.
+    "raw_msg":              (None, "none", "mdi:code-tags", "Raw Message"),
+
     # --- Utility Meters ---
     "Consumption":          ("ft³", "gas", "mdi:fire", "Gas Usage"),
     "consumption":          ("ft³", "gas", "mdi:fire", "Gas Usage"),


### PR DESCRIPTION
## Summary
Add field metadata for `raw_msg` - the raw hex message from rtl_433.

## Use Case
Useful for:
- Protocol debugging
- Reverse engineering unknown sensors
- Verifying message integrity
- Development and troubleshooting

## Fields Added
- `raw_msg`: Raw hex message string with appropriate icon (mdi:code-tags)

## Test plan
- [ ] Verify raw_msg field appears when rtl_433 outputs it
- [ ] Verify hex string displays correctly in HA