### PR TITLE
feat: add SDR health monitoring with binary_sensor alert

### DIFF
--- a/config.py
+++ b/config.py
@@ -210,6 +210,20 @@ class Settings(BaseSettings):
         description="Seconds battery_ok must be OK before clearing a low alert (0 disables).",
     )
 
+    # --- SDR Health Monitoring ---
+    sdr_health_restart_threshold: int = Field(
+        default=3,
+        description="Number of restarts within window to trigger health alert.",
+    )
+    sdr_health_restart_window: int = Field(
+        default=600,
+        description="Window in seconds for restart loop detection (default: 10 min).",
+    )
+    sdr_health_no_data_timeout: int = Field(
+        default=900,
+        description="Seconds without data to trigger health alert (default: 15 min).",
+    )
+
     @property
     def id_suffix(self) -> str:
         return "_v2" if self.force_new_ids else ""
@@ -270,3 +284,8 @@ VERBOSE_TRANSMISSIONS = settings.verbose_transmissions
 
 # Battery behavior
 BATTERY_OK_CLEAR_AFTER = settings.battery_ok_clear_after
+
+# SDR health monitoring
+SDR_HEALTH_RESTART_THRESHOLD = settings.sdr_health_restart_threshold
+SDR_HEALTH_RESTART_WINDOW = settings.sdr_health_restart_window
+SDR_HEALTH_NO_DATA_TIMEOUT = settings.sdr_health_no_data_timeout

--- a/config.yaml
+++ b/config.yaml
@@ -39,7 +39,14 @@ options:
   # --- Battery alert behavior (battery_ok -> Battery Low) ---
   # 0 disables latching and clears low on the next OK
   battery_ok_clear_after: 300
-  
+
+  # --- SDR Health Monitoring ---
+  # Publishes binary_sensor.sdr_health_alert (device_class: problem) for HA automations.
+  # Alert conditions: restart loops, no data received, USB/crash errors.
+  sdr_health_restart_threshold: 3      # Restarts within window to trigger alert
+  sdr_health_restart_window: 600       # Window in seconds (default: 10 min)
+  sdr_health_no_data_timeout: 900      # Seconds without data to trigger alert (default: 15 min)
+
   # --- DEFAULTS (Add-on UI) ---
   # Global defaults are NOT exposed in the add-on UI.
   # In add-on mode, use rtl_config below to set freq/rate/hop per-radio.
@@ -97,6 +104,11 @@ schema:
   rtl_auto_band_plan: list(auto|us|eu|world)
 
   battery_ok_clear_after: int
+
+  # SDR health monitoring
+  sdr_health_restart_threshold: int?
+  sdr_health_restart_window: int?
+  sdr_health_no_data_timeout: int?
 
   # --- DELETED GLOBAL SCHEMA ---
   # The UI will no longer show the 3 text boxes for defaults.

--- a/field_meta.py
+++ b/field_meta.py
@@ -10,6 +10,10 @@ FIELD_META = {
     # "sys_cfg_whitelist":    ("", "none", "mdi:playlist-check", "Whitelist"),
     # "sys_cfg_sensors":      ("", "none", "mdi:eye-settings", "Main Sensors"),
 
+    # --- SDR Health Monitoring ---
+    "sdr_health_alert":     (None, "problem", "mdi:alert-octagon", "SDR Health Alert"),
+    "sdr_health_reason":    (None, "none", "mdi:information", "Health Alert Reason"),
+
     # --- System Diagnostics (Existing) ---
     "sys_device_count":     ("dev", "none", "mdi:counter", "Active Devices"),
     # "sys_device_list":      ("", "none", "mdi:format-list-bulleted", "Device List"),

--- a/mqtt_handler.py
+++ b/mqtt_handler.py
@@ -696,3 +696,70 @@ class HomeNodeMQTT:
                 # --- NEW: Check Verbosity Setting ---
                 if config.VERBOSE_TRANSMISSIONS:
                     print(f" -> TX {device_name} [{field}]: {out_value}")
+
+    def send_health_alert(
+        self,
+        sensor_id: str,
+        is_problem: bool,
+        reason: str,
+        device_name: str,
+        device_model: str,
+    ) -> None:
+        """Publish SDR health alert as binary_sensor with reason attribute.
+
+        Args:
+            sensor_id: Base device ID (e.g., system MAC)
+            is_problem: True if there's a health problem (ON state)
+            reason: Human-readable reason for the alert
+            device_name: HA device name
+            device_model: HA device model
+        """
+        clean_id = clean_mac(sensor_id)
+        field = "sdr_health_alert"
+        unique_id = f"{clean_id}_{field}{config.ID_SUFFIX}"
+        state_topic = f"home/rtl_devices/{clean_id}/{field}"
+        attr_topic = f"home/rtl_devices/{clean_id}/{field}/attributes"
+
+        with self.discovery_lock:
+            # Publish discovery if not already done
+            if unique_id not in self.discovery_published:
+                sys_id = get_system_mac().replace(":", "").lower()
+                device_registry = {
+                    "identifiers": [f"rtl433_{config.BRIDGE_NAME}_{sys_id}"],
+                    "manufacturer": "rtl-haos",
+                    "model": device_model,
+                    "name": device_name,
+                    "sw_version": self.sw_version,
+                }
+
+                payload = {
+                    "name": "SDR Health Alert",
+                    "state_topic": state_topic,
+                    "unique_id": unique_id,
+                    "device": device_registry,
+                    "device_class": "problem",
+                    "icon": "mdi:alert-octagon",
+                    "payload_on": "ON",
+                    "payload_off": "OFF",
+                    "json_attributes_topic": attr_topic,
+                    "availability_topic": self.TOPIC_AVAILABILITY,
+                }
+
+                config_topic = f"homeassistant/binary_sensor/{unique_id}/config"
+                self.client.publish(config_topic, json.dumps(payload), retain=True)
+                self.discovery_published.add(unique_id)
+
+        # Publish state
+        state_value = "ON" if is_problem else "OFF"
+        state_key = f"{unique_id}_state"
+        if self.last_sent_values.get(state_key) != state_value:
+            self.client.publish(state_topic, state_value, retain=True)
+            self.last_sent_values[state_key] = state_value
+
+        # Publish attributes (always update reason)
+        attr_payload = {"reason": reason if reason else "OK"}
+        attr_key = f"{unique_id}_attr"
+        attr_json = json.dumps(attr_payload)
+        if self.last_sent_values.get(attr_key) != attr_json:
+            self.client.publish(attr_topic, attr_json, retain=True)
+            self.last_sent_values[attr_key] = attr_json

--- a/rtl_manager.py
+++ b/rtl_manager.py
@@ -18,6 +18,7 @@ from typing import Optional
 
 import config
 from utils import clean_mac, calculate_dew_point
+from sdr_health import get_health_monitor
 
 # --- Process Tracking ---
 ACTIVE_PROCESSES = []
@@ -844,6 +845,11 @@ def rtl_loop(radio_config: dict, mqtt_handler, data_processor, sys_id: str, sys_
                             data_raw = None
 
 
+                    # Record health: valid data received
+                    health = get_health_monitor()
+                    health.record_data_received(radio_name)
+                    health.clear_error(radio_name)
+
                     # Mark online once we see valid JSON
                     now = time.time()
                     if config.RTL_SHOW_TIMESTAMPS:
@@ -969,6 +975,9 @@ def rtl_loop(radio_config: dict, mqtt_handler, data_processor, sys_id: str, sys_
                             status,
                             friendly_name=status_friendly,
                         )
+                        # Record health: error detected
+                        health = get_health_monitor()
+                        health.record_error(radio_name, status.replace("Error: ", ""))
                         continue
 
                     # Ignore startup chatter that isn't actionable
@@ -1007,5 +1016,8 @@ def rtl_loop(radio_config: dict, mqtt_handler, data_processor, sys_id: str, sys_
                     )
 
         last_online_mark = 0.0
+        # Record health: restart
+        health = get_health_monitor()
+        health.record_restart(radio_name)
         print(f"[RTL] {radio_name} crashed/stopped. Restarting in 5s...")
         time.sleep(5)

--- a/sdr_health.py
+++ b/sdr_health.py
@@ -1,0 +1,161 @@
+# sdr_health.py
+"""
+SDR Health Monitoring for rtl-haos.
+
+Tracks SDR health conditions and provides a binary health status for Home Assistant.
+Alert conditions:
+  - Crash/restart loop: 3+ restarts within 10 minutes (configurable)
+  - Zero data: No sensor readings received in 15 minutes (configurable)
+  - USB errors: Device disconnected, busy, or permission denied
+  - rtl_433 crash: Segfault, illegal instruction
+"""
+from __future__ import annotations
+
+import threading
+import time
+from typing import Optional
+
+import config
+
+
+class SDRHealthMonitor:
+    """Singleton health monitor for SDR radios."""
+
+    _instance: Optional["SDRHealthMonitor"] = None
+    _lock = threading.Lock()
+
+    def __new__(cls) -> "SDRHealthMonitor":
+        if cls._instance is None:
+            with cls._lock:
+                if cls._instance is None:
+                    cls._instance = super().__new__(cls)
+                    cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self) -> None:
+        if self._initialized:
+            return
+        self._initialized = True
+
+        # Track restart timestamps per radio for loop detection
+        self.restart_times: dict[str, list[float]] = {}
+
+        # Track last data received timestamp per radio
+        self.last_data_time: dict[str, float] = {}
+
+        # Track current error state per radio (None = no error)
+        self.current_errors: dict[str, str] = {}
+
+        # Overall alert state (cached for efficiency)
+        self._alert_state: bool = False
+        self._alert_reason: str = ""
+
+        # Lock for thread-safe access
+        self._state_lock = threading.Lock()
+
+    def record_restart(self, radio_name: str) -> None:
+        """Record a radio restart for loop detection."""
+        now = time.time()
+        with self._state_lock:
+            if radio_name not in self.restart_times:
+                self.restart_times[radio_name] = []
+            self.restart_times[radio_name].append(now)
+
+            # Prune old timestamps outside the window
+            window = getattr(config, "SDR_HEALTH_RESTART_WINDOW", 600)
+            cutoff = now - window
+            self.restart_times[radio_name] = [
+                t for t in self.restart_times[radio_name] if t > cutoff
+            ]
+
+    def record_data_received(self, radio_name: str) -> None:
+        """Record that valid data was received from a radio."""
+        now = time.time()
+        with self._state_lock:
+            self.last_data_time[radio_name] = now
+
+    def record_error(self, radio_name: str, error_type: str) -> None:
+        """Record an error condition for a radio."""
+        with self._state_lock:
+            self.current_errors[radio_name] = error_type
+
+    def clear_error(self, radio_name: str) -> None:
+        """Clear error state for a radio (e.g., when it comes back online)."""
+        with self._state_lock:
+            self.current_errors.pop(radio_name, None)
+
+    def check_health(self) -> tuple[bool, str]:
+        """Check overall SDR health.
+
+        Returns:
+            tuple[bool, str]: (is_problem, reason)
+                - is_problem: True if there's a health problem
+                - reason: Human-readable reason for the problem, or empty if healthy
+        """
+        now = time.time()
+        problems: list[str] = []
+
+        with self._state_lock:
+            # Check for restart loops
+            threshold = getattr(config, "SDR_HEALTH_RESTART_THRESHOLD", 3)
+            window = getattr(config, "SDR_HEALTH_RESTART_WINDOW", 600)
+            cutoff = now - window
+
+            for radio_name, timestamps in self.restart_times.items():
+                # Filter to recent timestamps
+                recent = [t for t in timestamps if t > cutoff]
+                self.restart_times[radio_name] = recent
+
+                if len(recent) >= threshold:
+                    problems.append(f"{radio_name}: restart loop ({len(recent)}x in {window}s)")
+
+            # Check for zero data (only if we've seen data before)
+            timeout = getattr(config, "SDR_HEALTH_NO_DATA_TIMEOUT", 900)
+            for radio_name, last_time in self.last_data_time.items():
+                if (now - last_time) > timeout:
+                    minutes = int((now - last_time) / 60)
+                    problems.append(f"{radio_name}: no data ({minutes}m)")
+
+            # Check for current errors
+            for radio_name, error_type in self.current_errors.items():
+                problems.append(f"{radio_name}: {error_type}")
+
+        if problems:
+            # Combine all problems into a single reason string
+            reason = "; ".join(problems)
+            self._alert_state = True
+            self._alert_reason = reason
+            return (True, reason)
+
+        self._alert_state = False
+        self._alert_reason = ""
+        return (False, "")
+
+    def get_all_radios(self) -> set[str]:
+        """Get the set of all known radio names."""
+        with self._state_lock:
+            radios = set(self.restart_times.keys())
+            radios.update(self.last_data_time.keys())
+            radios.update(self.current_errors.keys())
+            return radios
+
+    def reset(self) -> None:
+        """Reset all health state (useful for testing)."""
+        with self._state_lock:
+            self.restart_times.clear()
+            self.last_data_time.clear()
+            self.current_errors.clear()
+            self._alert_state = False
+            self._alert_reason = ""
+
+
+# Module-level singleton instance
+_health_monitor: Optional[SDRHealthMonitor] = None
+
+
+def get_health_monitor() -> SDRHealthMonitor:
+    """Get the singleton health monitor instance."""
+    global _health_monitor
+    if _health_monitor is None:
+        _health_monitor = SDRHealthMonitor()
+    return _health_monitor

--- a/system_monitor.py
+++ b/system_monitor.py
@@ -38,7 +38,8 @@ except ImportError as e:
 # Safe imports for the rest of the app
 import config
 from mqtt_handler import HomeNodeMQTT
-from utils import get_system_mac 
+from utils import get_system_mac
+from sdr_health import get_health_monitor 
 
 def format_list_for_ha(data_list):
     """Joins a list into a string and truncates to ~250 chars."""
@@ -125,7 +126,16 @@ def system_stats_loop(mqtt_handler, DEVICE_ID, MODEL_NAME):
             # mqtt_handler.send_sensor(DEVICE_ID, "sys_cfg_blacklist", format_list_for_ha(bl), device_name, MODEL_NAME, is_rtl=True)
             # mqtt_handler.send_sensor(DEVICE_ID, "sys_cfg_whitelist", format_list_for_ha(wl), device_name, MODEL_NAME, is_rtl=True)
             # mqtt_handler.send_sensor(DEVICE_ID, "sys_cfg_sensors", format_list_for_ha(ms), device_name, MODEL_NAME, is_rtl=True)
-            
+
+            # C. SDR Health Monitoring
+            health = get_health_monitor()
+            is_problem, reason = health.check_health()
+            mqtt_handler.send_health_alert(DEVICE_ID, is_problem, reason, device_name, MODEL_NAME)
+            # Also publish reason as a text sensor for dashboard visibility
+            mqtt_handler.send_sensor(
+                DEVICE_ID, "sdr_health_reason", reason or "OK", device_name, MODEL_NAME, is_rtl=False
+            )
+
         except Exception as e:
             print(f"[ERROR] Bridge Stats update failed: {e}")
 

--- a/tests/test_sdr_health.py
+++ b/tests/test_sdr_health.py
@@ -1,0 +1,236 @@
+# tests/test_sdr_health.py
+"""Tests for SDR health monitoring."""
+import time
+
+import pytest
+
+import config
+import sdr_health
+from sdr_health import SDRHealthMonitor, get_health_monitor
+
+
+@pytest.fixture(autouse=True)
+def reset_health_singleton():
+    """Reset the singleton and its state before each test."""
+    sdr_health._health_monitor = None
+    SDRHealthMonitor._instance = None
+    yield
+    # Cleanup after test
+    sdr_health._health_monitor = None
+    SDRHealthMonitor._instance = None
+
+
+@pytest.fixture
+def health():
+    """Get a fresh health monitor instance."""
+    return get_health_monitor()
+
+
+class TestSDRHealthMonitorSingleton:
+    """Test singleton behavior of SDRHealthMonitor."""
+
+    def test_singleton_returns_same_instance(self):
+        """Multiple calls to get_health_monitor return the same instance."""
+        h1 = get_health_monitor()
+        h2 = get_health_monitor()
+        assert h1 is h2
+
+    def test_direct_instantiation_returns_singleton(self):
+        """Direct instantiation also returns the singleton."""
+        h1 = SDRHealthMonitor()
+        h2 = SDRHealthMonitor()
+        assert h1 is h2
+
+
+class TestRestartLoopDetection:
+    """Test restart loop detection."""
+
+    def test_no_restarts_is_healthy(self, health, monkeypatch):
+        """No restarts means healthy."""
+        is_problem, reason = health.check_health()
+        assert is_problem is False
+        assert reason == ""
+
+    def test_single_restart_not_a_problem(self, health, monkeypatch):
+        """A single restart should not trigger an alert."""
+        monkeypatch.setattr(config, "SDR_HEALTH_RESTART_THRESHOLD", 3, raising=False)
+        monkeypatch.setattr(config, "SDR_HEALTH_RESTART_WINDOW", 600, raising=False)
+
+        health.record_restart("Radio1")
+
+        is_problem, reason = health.check_health()
+        assert is_problem is False
+        assert reason == ""
+
+    def test_restart_loop_triggers_alert(self, health, monkeypatch):
+        """Multiple restarts within window trigger an alert."""
+        monkeypatch.setattr(config, "SDR_HEALTH_RESTART_THRESHOLD", 3, raising=False)
+        monkeypatch.setattr(config, "SDR_HEALTH_RESTART_WINDOW", 600, raising=False)
+
+        # Record 3 restarts
+        health.record_restart("Radio1")
+        health.record_restart("Radio1")
+        health.record_restart("Radio1")
+
+        is_problem, reason = health.check_health()
+        assert is_problem is True
+        assert "Radio1" in reason
+        assert "restart loop" in reason
+
+    def test_restarts_outside_window_not_counted(self, health, monkeypatch):
+        """Restarts outside the window should be pruned."""
+        monkeypatch.setattr(config, "SDR_HEALTH_RESTART_THRESHOLD", 3, raising=False)
+        monkeypatch.setattr(config, "SDR_HEALTH_RESTART_WINDOW", 600, raising=False)
+
+        # Manually insert old timestamps
+        old_time = time.time() - 700  # Outside window
+        health.restart_times["Radio1"] = [old_time, old_time + 1, old_time + 2]
+
+        # Record one new restart
+        health.record_restart("Radio1")
+
+        is_problem, reason = health.check_health()
+        # Only 1 restart in window, should be healthy
+        assert is_problem is False
+
+
+class TestZeroDataDetection:
+    """Test zero-data detection."""
+
+    def test_no_data_ever_is_healthy(self, health, monkeypatch):
+        """If we've never seen data, no timeout alert (no radios known)."""
+        monkeypatch.setattr(config, "SDR_HEALTH_NO_DATA_TIMEOUT", 900, raising=False)
+
+        is_problem, reason = health.check_health()
+        assert is_problem is False
+
+    def test_recent_data_is_healthy(self, health, monkeypatch):
+        """Recent data within timeout is healthy."""
+        monkeypatch.setattr(config, "SDR_HEALTH_NO_DATA_TIMEOUT", 900, raising=False)
+
+        health.record_data_received("Radio1")
+
+        is_problem, reason = health.check_health()
+        assert is_problem is False
+
+    def test_stale_data_triggers_alert(self, health, monkeypatch):
+        """No data for longer than timeout triggers alert."""
+        monkeypatch.setattr(config, "SDR_HEALTH_NO_DATA_TIMEOUT", 900, raising=False)
+
+        # Set last data time to be old
+        old_time = time.time() - 1000  # Older than timeout
+        health.last_data_time["Radio1"] = old_time
+
+        is_problem, reason = health.check_health()
+        assert is_problem is True
+        assert "Radio1" in reason
+        assert "no data" in reason
+
+
+class TestErrorRecording:
+    """Test error recording and clearing."""
+
+    def test_record_error_triggers_alert(self, health):
+        """Recording an error triggers an alert."""
+        health.record_error("Radio1", "USB disconnected")
+
+        is_problem, reason = health.check_health()
+        assert is_problem is True
+        assert "Radio1" in reason
+        assert "USB disconnected" in reason
+
+    def test_clear_error_removes_alert(self, health):
+        """Clearing an error removes the alert."""
+        health.record_error("Radio1", "USB disconnected")
+        health.clear_error("Radio1")
+
+        is_problem, reason = health.check_health()
+        assert is_problem is False
+        assert reason == ""
+
+    def test_clear_error_nonexistent_is_safe(self, health):
+        """Clearing a non-existent error is safe (no error)."""
+        health.clear_error("NonExistent")
+        is_problem, reason = health.check_health()
+        assert is_problem is False
+
+
+class TestMultipleConditions:
+    """Test multiple health conditions combined."""
+
+    def test_multiple_radios_with_errors(self, health):
+        """Multiple radios can have separate errors."""
+        health.record_error("Radio1", "USB disconnected")
+        health.record_error("Radio2", "Permission denied")
+
+        is_problem, reason = health.check_health()
+        assert is_problem is True
+        assert "Radio1" in reason
+        assert "Radio2" in reason
+        assert "USB disconnected" in reason
+        assert "Permission denied" in reason
+
+    def test_combined_conditions(self, health, monkeypatch):
+        """Multiple condition types combine into one reason."""
+        monkeypatch.setattr(config, "SDR_HEALTH_RESTART_THRESHOLD", 2, raising=False)
+        monkeypatch.setattr(config, "SDR_HEALTH_RESTART_WINDOW", 600, raising=False)
+        monkeypatch.setattr(config, "SDR_HEALTH_NO_DATA_TIMEOUT", 900, raising=False)
+
+        # Restart loop for Radio1
+        health.record_restart("Radio1")
+        health.record_restart("Radio1")
+
+        # Error for Radio2
+        health.record_error("Radio2", "USB busy")
+
+        is_problem, reason = health.check_health()
+        assert is_problem is True
+        assert "restart loop" in reason
+        assert "USB busy" in reason
+
+
+class TestReset:
+    """Test the reset functionality."""
+
+    def test_reset_clears_all_state(self, health, monkeypatch):
+        """reset() clears all tracked state."""
+        monkeypatch.setattr(config, "SDR_HEALTH_RESTART_THRESHOLD", 2, raising=False)
+        monkeypatch.setattr(config, "SDR_HEALTH_RESTART_WINDOW", 600, raising=False)
+
+        health.record_restart("Radio1")
+        health.record_restart("Radio1")
+        health.record_error("Radio2", "Error")
+        health.record_data_received("Radio3")
+
+        # Should have issues
+        is_problem, _ = health.check_health()
+        assert is_problem is True
+
+        # Reset
+        health.reset()
+
+        # Should be healthy
+        is_problem, reason = health.check_health()
+        assert is_problem is False
+        assert reason == ""
+        assert len(health.restart_times) == 0
+        assert len(health.last_data_time) == 0
+        assert len(health.current_errors) == 0
+
+
+class TestGetAllRadios:
+    """Test get_all_radios method."""
+
+    def test_get_all_radios_empty(self, health):
+        """Initially returns empty set."""
+        radios = health.get_all_radios()
+        assert radios == set()
+
+    def test_get_all_radios_from_various_sources(self, health):
+        """Returns radios from all tracking dicts."""
+        health.record_restart("Radio1")
+        health.record_data_received("Radio2")
+        health.record_error("Radio3", "Error")
+
+        radios = health.get_all_radios()
+        assert radios == {"Radio1", "Radio2", "Radio3"}

--- a/tests/test_sdr_health_mqtt.py
+++ b/tests/test_sdr_health_mqtt.py
@@ -1,0 +1,158 @@
+# tests/test_sdr_health_mqtt.py
+"""Tests for SDR health alert MQTT publishing."""
+import json
+
+import pytest
+
+import config
+import mqtt_handler
+
+from ._mqtt_test_helpers import DummyClient, last_published
+
+
+def _patch_common(monkeypatch):
+    """Common patches for MQTT handler tests."""
+    monkeypatch.setattr(mqtt_handler.mqtt, "Client", lambda *a, **k: DummyClient())
+    monkeypatch.setattr(mqtt_handler, "clean_mac", lambda s: "testdevice")
+    monkeypatch.setattr(mqtt_handler, "get_system_mac", lambda: "aa:bb:cc:dd:ee:ff")
+    monkeypatch.setattr(config, "ID_SUFFIX", "_T", raising=False)
+    monkeypatch.setattr(config, "BRIDGE_NAME", "TestBridge", raising=False)
+    monkeypatch.setattr(config, "BRIDGE_ID", "testid", raising=False)
+    monkeypatch.setattr(config, "RTL_EXPIRE_AFTER", 60, raising=False)
+    monkeypatch.setattr(config, "VERBOSE_TRANSMISSIONS", False, raising=False)
+
+
+class TestSendHealthAlert:
+    """Tests for the send_health_alert method."""
+
+    def test_publishes_binary_sensor_discovery(self, monkeypatch):
+        """send_health_alert publishes binary_sensor discovery config."""
+        _patch_common(monkeypatch)
+
+        h = mqtt_handler.HomeNodeMQTT(version="vtest")
+        c = h.client
+
+        h.send_health_alert("testid", False, "", "Test Bridge", "TestBridge")
+
+        # Find the discovery config
+        config_topic = "homeassistant/binary_sensor/testdevice_sdr_health_alert_T/config"
+        found = [p for p in c.published if p[0] == config_topic]
+        assert len(found) == 1
+
+        payload = json.loads(found[0][1])
+        assert payload["name"] == "SDR Health Alert"
+        assert payload["device_class"] == "problem"
+        assert payload["payload_on"] == "ON"
+        assert payload["payload_off"] == "OFF"
+        assert "json_attributes_topic" in payload
+
+    def test_publishes_state_off_when_healthy(self, monkeypatch):
+        """send_health_alert publishes OFF state when healthy."""
+        _patch_common(monkeypatch)
+
+        h = mqtt_handler.HomeNodeMQTT(version="vtest")
+        c = h.client
+
+        h.send_health_alert("testid", False, "", "Test Bridge", "TestBridge")
+
+        state_topic = "home/rtl_devices/testdevice/sdr_health_alert"
+        _t, payload, _r = last_published(c, state_topic)
+        assert payload == "OFF"
+
+    def test_publishes_state_on_when_problem(self, monkeypatch):
+        """send_health_alert publishes ON state when problem detected."""
+        _patch_common(monkeypatch)
+
+        h = mqtt_handler.HomeNodeMQTT(version="vtest")
+        c = h.client
+
+        h.send_health_alert("testid", True, "USB disconnected", "Test Bridge", "TestBridge")
+
+        state_topic = "home/rtl_devices/testdevice/sdr_health_alert"
+        _t, payload, _r = last_published(c, state_topic)
+        assert payload == "ON"
+
+    def test_publishes_attributes_with_reason(self, monkeypatch):
+        """send_health_alert publishes attributes with reason."""
+        _patch_common(monkeypatch)
+
+        h = mqtt_handler.HomeNodeMQTT(version="vtest")
+        c = h.client
+
+        h.send_health_alert("testid", True, "Restart loop detected", "Test Bridge", "TestBridge")
+
+        attr_topic = "home/rtl_devices/testdevice/sdr_health_alert/attributes"
+        _t, payload, _r = last_published(c, attr_topic)
+        attrs = json.loads(payload)
+        assert attrs["reason"] == "Restart loop detected"
+
+    def test_attributes_show_ok_when_healthy(self, monkeypatch):
+        """Attributes show 'OK' when healthy."""
+        _patch_common(monkeypatch)
+
+        h = mqtt_handler.HomeNodeMQTT(version="vtest")
+        c = h.client
+
+        h.send_health_alert("testid", False, "", "Test Bridge", "TestBridge")
+
+        attr_topic = "home/rtl_devices/testdevice/sdr_health_alert/attributes"
+        _t, payload, _r = last_published(c, attr_topic)
+        attrs = json.loads(payload)
+        assert attrs["reason"] == "OK"
+
+    def test_discovery_published_once(self, monkeypatch):
+        """Discovery is only published once."""
+        _patch_common(monkeypatch)
+
+        h = mqtt_handler.HomeNodeMQTT(version="vtest")
+        c = h.client
+
+        h.send_health_alert("testid", False, "", "Test Bridge", "TestBridge")
+        h.send_health_alert("testid", True, "Error", "Test Bridge", "TestBridge")
+        h.send_health_alert("testid", False, "", "Test Bridge", "TestBridge")
+
+        config_topic = "homeassistant/binary_sensor/testdevice_sdr_health_alert_T/config"
+        found = [p for p in c.published if p[0] == config_topic]
+        assert len(found) == 1
+
+    def test_state_transition_publishes(self, monkeypatch):
+        """State transitions are published."""
+        _patch_common(monkeypatch)
+
+        h = mqtt_handler.HomeNodeMQTT(version="vtest")
+        c = h.client
+
+        state_topic = "home/rtl_devices/testdevice/sdr_health_alert"
+
+        # Initial healthy
+        h.send_health_alert("testid", False, "", "Test Bridge", "TestBridge")
+        states = [p for p in c.published if p[0] == state_topic]
+        assert states[-1][1] == "OFF"
+
+        # Transition to problem
+        h.send_health_alert("testid", True, "Error", "Test Bridge", "TestBridge")
+        states = [p for p in c.published if p[0] == state_topic]
+        assert states[-1][1] == "ON"
+
+        # Back to healthy
+        h.send_health_alert("testid", False, "", "Test Bridge", "TestBridge")
+        states = [p for p in c.published if p[0] == state_topic]
+        assert states[-1][1] == "OFF"
+
+    def test_device_info_in_discovery(self, monkeypatch):
+        """Discovery payload includes correct device info."""
+        _patch_common(monkeypatch)
+
+        h = mqtt_handler.HomeNodeMQTT(version="vtest")
+        c = h.client
+
+        h.send_health_alert("testid", False, "", "Test Bridge", "TestBridge")
+
+        config_topic = "homeassistant/binary_sensor/testdevice_sdr_health_alert_T/config"
+        _t, payload, _r = last_published(c, config_topic)
+        cfg = json.loads(payload)
+
+        assert "device" in cfg
+        assert cfg["device"]["manufacturer"] == "rtl-haos"
+        assert cfg["device"]["model"] == "TestBridge"
+        assert cfg["device"]["sw_version"] == "vtest"


### PR DESCRIPTION
## Summary

Adds health monitoring that detects SDR problems and publishes a `binary_sensor` to Home Assistant. Users can then create their own automations to send notifications when problems occur.

**Alert conditions:**
- Restart loop: 3+ restarts within 10 minutes
- Zero data: No sensor readings in 15 minutes  
- USB errors: Device disconnected, busy, or permission denied
- rtl_433 crash: Segfault, illegal instruction

**Why binary_sensor over direct notifications:**
- No HA API credentials needed in the add-on
- User controls notification method (push, email, SMS, etc.)
- Integrates with existing HA automation patterns
- Stateful - shows current health in HA dashboard

## Changes

- `sdr_health.py` (new): Thread-safe health monitor singleton
- `config.py`: Add configurable thresholds
- `config.yaml`: Expose settings in add-on UI
- `field_meta.py`: Add sensor metadata
- `mqtt_handler.py`: Add `send_health_alert()` method
- `rtl_manager.py`: Hook health monitor at restart/error/data points
- `system_monitor.py`: Publish health status every 60s
- Tests: 25 new tests for health logic and MQTT publishing

## Configuration

All thresholds are configurable in the add-on UI:
- `sdr_health_restart_threshold` (default: 3)
- `sdr_health_restart_window` (default: 600s / 10 min)
- `sdr_health_no_data_timeout` (default: 900s / 15 min)

## Example HA Automation

```yaml
automation:
  - alias: "SDR Health Alert"
    trigger:
      - platform: state
        entity_id: binary_sensor.rtl_haos_bridge_sdr_health_alert
        to: "on"
    action:
      - service: notify.mobile_app
        data:
          title: "SDR Alert"
          message: >
            {{ state_attr('binary_sensor.rtl_haos_bridge_sdr_health_alert', 'reason') }}
```

## Test plan

- [ ] Start rtl-haos, verify `binary_sensor.sdr_health_alert` appears in HA as `OFF`
- [ ] Unplug SDR dongle, verify alert goes `ON` with reason
- [ ] Plug SDR back in, verify alert returns to `OFF`
- [ ] Test restart loop by killing rtl_433 process repeatedly
- [ ] Verify configurable timeouts work as expected