### PR TITLE
feat: add 'closed' to main_sensors for door/window contact sensors

### DIFF
--- a/config.py
+++ b/config.py
@@ -189,6 +189,7 @@ class Settings(BaseSettings):
             "volume_ft3",
             "volume_m3",
             "moisture",
+            "closed",  # door/window contact sensors
         ]
     )
 


### PR DESCRIPTION
## Summary

Security sensors like DSC report a `closed` field for door/window state. This field should be a primary entity, not diagnostic, since it represents the main sensor reading (open/closed state).

Currently, DSC security sensors show the `closed` sensor as "diagnostic" in Home Assistant, which hides it from the main device view. Users expect the door/window open/closed state to be the primary entity.

## Changes

- Added `"closed"` to the `main_sensors` default list in `config.py`

## Test plan

- Deploy with DSC security sensors
- Verify `closed` entities appear as primary (not diagnostic) in Home Assistant device views