### PR TITLE
feat: rtl_single_sdr_mode — use 900 MHz band plan on a single SDR (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Single-SDR band plan (#103)
+- **NEW:** `rtl_single_sdr_mode` option lets a single dongle use the **secondary (900 MHz) band plan** instead of being locked to the 433 MHz primary. Set to `us`/`eu`/`world`/`auto` to reach utility/meter bands with one SDR; defaults to `off` (legacy behavior). Reuses the existing Radio #2 logic and honors `rtl_auto_secondary_freq`/`rtl_auto_secondary_rate`.
+
 ## v1.2.0-rc.2 (Release Candidate 2)
 
 ### HA add-on config + rtl_tcp quality-of-life

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ See rtl_433 documentation for supported devices: https://github.com/merbanan/rtl
     - **US/CA/AU/NZ (and most others):** 915 MHz
     - If Home Assistant country is unknown, it will hop 868/915 on Radio #2
   - **Radio #3 (if present):** a regional hopper for “interesting” bands that **does not intentionally overlap** Radio 1/2.
+  - **Single-SDR band plan (`rtl_single_sdr_mode`):** With only one dongle, auto mode normally starts it as **Radio #1 (433.92 MHz)**, so the 900 MHz "Radio #2" band used for utility/water/gas meters is unreachable. Set `rtl_single_sdr_mode` to `us`/`eu`/`world`/`auto` to make a solo dongle adopt the **secondary (high-band) plan** instead — e.g. `us` → 915 MHz. Defaults to `off` (legacy behavior). Honors `rtl_auto_secondary_freq` / `rtl_auto_secondary_rate` just like Radio #2.
   - Want full control of rates / hop intervals / exact freqs? Define `rtl_config` (manual mode) and you are responsible for the complete radio configuration.
 
 - **Zero-Config Discovery:** Sensors appear automatically in Home Assistant (via MQTT Discovery) with correct units, icons, and friendly names.

--- a/config.py
+++ b/config.py
@@ -110,6 +110,20 @@ class Settings(BaseSettings):
     # If left blank, we fall back to the 'auto' behavior.
     rtl_auto_secondary_freq: str = Field(default="")
 
+    # Single-SDR band-plan mode (issue #103).
+    # When only ONE dongle is present it is normally started as the PRIMARY radio
+    # (rtl_default_freq, typically 433.92M), so the 900 MHz "secondary" band plan
+    # used for utility/meter decoding is unreachable. Setting this to anything
+    # other than "off" makes a solo dongle adopt the SECONDARY band-plan behavior
+    # (the same logic Radio #2 uses in auto multi-mode).
+    #  - off    : legacy behavior (solo dongle = primary / rtl_default_freq)
+    #  - auto   : infer secondary band from HA country (else hop 868/915)
+    #  - us     : 915M
+    #  - eu     : 868M
+    #  - world  : hop 868M,915M
+    # Honors rtl_auto_secondary_freq / rtl_auto_secondary_rate just like Radio #2.
+    rtl_single_sdr_mode: str = Field(default="off")
+
     # Auto primary/secondary rates (freqs are chosen elsewhere)
     rtl_auto_primary_rate: str = Field(default="250k")
     rtl_auto_secondary_rate: str = Field(default="1024k")
@@ -275,6 +289,7 @@ RTL_AUTO_MAX_RADIOS = settings.rtl_auto_max_radios
 RTL_AUTO_HARD_CAP = settings.rtl_auto_hard_cap
 RTL_AUTO_BAND_PLAN = settings.rtl_auto_band_plan
 RTL_AUTO_SECONDARY_FREQ = settings.rtl_auto_secondary_freq
+RTL_SINGLE_SDR_MODE = settings.rtl_single_sdr_mode
 RTL_AUTO_PRIMARY_RATE = settings.rtl_auto_primary_rate
 RTL_AUTO_SECONDARY_RATE = settings.rtl_auto_secondary_rate
 RTL_AUTO_HOPPER_FREQS = settings.rtl_auto_hopper_freqs

--- a/config.yaml
+++ b/config.yaml
@@ -64,6 +64,12 @@ options:
   # manually (and you are responsible for the full radio config).
   rtl_auto_band_plan: "auto"
 
+  # Single-SDR band-plan mode (issue #103). With only one dongle it normally runs
+  # as the 433 MHz primary, so the 900 MHz meter band is unreachable. Set this to
+  # us/eu/world/auto to make a solo dongle use the secondary (900 MHz) band plan.
+  #   off | auto | us | eu | world
+  rtl_single_sdr_mode: "off"
+
   # --- Device Filtering ---
   # Define device patterns to allow or disallow.
   # Patterns use shell-style glob matching (Python fnmatch): *, ?, and [] character classes.
@@ -102,6 +108,7 @@ schema:
 
   # Auto multi-radio (when rtl_config is empty)
   rtl_auto_band_plan: list(auto|us|eu|world)
+  rtl_single_sdr_mode: list(off|auto|us|eu|world)
 
   battery_ok_clear_after: int
 

--- a/main.py
+++ b/main.py
@@ -535,31 +535,76 @@ def main():
                     )
 
             else:
-                print("[STARTUP] Unconfigured Mode: Starting PRIMARY radio only.")
-
                 dev = detected_devices[0]
                 dev_name = dev.get("name", "Primary")
 
-                # 1. SMART DEFAULT LOGIC
-                def_freqs = config.RTL_DEFAULT_FREQ.split(",")
-                def_hop = config.RTL_DEFAULT_HOP_INTERVAL
-                if len(def_freqs) < 2:
-                    def_hop = 0
+                # Single-SDR band-plan mode (issue #103): let a solo dongle adopt the
+                # SECONDARY (900 MHz / meter) band plan instead of being locked to the
+                # primary 433 MHz default. Reuses the exact Radio #2 logic.
+                single_mode = str(getattr(config, "RTL_SINGLE_SDR_MODE", "off") or "off").strip().lower()
 
-                radio_setup = {
-                    "slot": 0,
-                    "hop_interval": def_hop,
-                    "rate": config.RTL_DEFAULT_RATE,
-                    "freq": config.RTL_DEFAULT_FREQ
-                }
+                if single_mode not in ("", "off", "false", "none", "0"):
+                    print("[STARTUP] Unconfigured Mode: Single-SDR band-plan mode "
+                          f"(rtl_single_sdr_mode={single_mode}) -> using secondary band plan.")
 
-                radio_setup.update(dev)
+                    country = get_homeassistant_country_code()
+                    sec_override = str(getattr(config, "RTL_AUTO_SECONDARY_FREQ", "") or "").strip()
+                    sec_freq, sec_hop = choose_secondary_band_defaults(
+                        plan=single_mode,
+                        country_code=country,
+                        secondary_override=sec_override,
+                    )
 
-                warns = validate_radio_config(radio_setup)
-                for w in warns:
-                    print(f"[STARTUP] DEFAULT CONFIG WARNING: [Radio: {dev_name}] {w}")
+                    sec_list = [s.strip() for s in str(sec_freq).split(",") if s.strip()]
+                    hop = int(sec_hop or 0)
+                    if len(sec_list) < 2:
+                        hop = 0
+                    elif hop <= 0:
+                        hop = 15
 
-                print(f"[STARTUP] Radio #1 ({dev['name']}) -> Defaulting to {radio_setup['freq']}")
+                    radio_setup = {
+                        "slot": 0,
+                        "hop_interval": hop,
+                        "rate": getattr(config, "RTL_AUTO_SECONDARY_RATE", "1024k"),
+                        "freq": sec_freq,
+                    }
+                    radio_setup.update(dev)
+
+                    warns = validate_radio_config(radio_setup)
+                    for w in warns:
+                        print(f"[STARTUP] DEFAULT CONFIG WARNING: [Radio: {dev_name}] {w}")
+
+                    if country:
+                        print(f"[STARTUP] Single-SDR Mode: HA country={country}, "
+                              f"plan={single_mode} -> {radio_setup['freq']}")
+                    else:
+                        print(f"[STARTUP] Single-SDR Mode: HA country=unknown, "
+                              f"plan={single_mode} -> {radio_setup['freq']}")
+                    print(f"[STARTUP] Radio #1 ({dev['name']}) -> {radio_setup['freq']} "
+                          f"(Rate: {radio_setup['rate']}, Hop: {radio_setup['hop_interval']})")
+                else:
+                    print("[STARTUP] Unconfigured Mode: Starting PRIMARY radio only.")
+
+                    # 1. SMART DEFAULT LOGIC
+                    def_freqs = config.RTL_DEFAULT_FREQ.split(",")
+                    def_hop = config.RTL_DEFAULT_HOP_INTERVAL
+                    if len(def_freqs) < 2:
+                        def_hop = 0
+
+                    radio_setup = {
+                        "slot": 0,
+                        "hop_interval": def_hop,
+                        "rate": config.RTL_DEFAULT_RATE,
+                        "freq": config.RTL_DEFAULT_FREQ
+                    }
+
+                    radio_setup.update(dev)
+
+                    warns = validate_radio_config(radio_setup)
+                    for w in warns:
+                        print(f"[STARTUP] DEFAULT CONFIG WARNING: [Radio: {dev_name}] {w}")
+
+                    print(f"[STARTUP] Radio #1 ({dev['name']}) -> Defaulting to {radio_setup['freq']}")
 
                 if len(detected_devices) > 1:
                     print(f"[STARTUP] WARNING: [System] {len(detected_devices)-1} additional SDR(s) detected but ignored. Enable Auto Multi-Radio or configure rtl_config to use them.")

--- a/tests/test_main_auto_multi_plan.py
+++ b/tests/test_main_auto_multi_plan.py
@@ -81,6 +81,8 @@ def _setup_main_for_test(monkeypatch, detected_devices, country_code):
     monkeypatch.setattr(main_mod.config, "RTL_AUTO_HOPPER_HOP_INTERVAL", 20)
     monkeypatch.setattr(main_mod.config, "RTL_AUTO_HOPPER_RATE", "1024k")
 
+    monkeypatch.setattr(main_mod.config, "RTL_SINGLE_SDR_MODE", "off")
+
     # Exit the infinite loop quickly (it sleeps(1) in the main loop)
     def fake_sleep(seconds):
         if seconds == 1:
@@ -155,5 +157,62 @@ def test_auto_multi_three_radios_unknown_country_splits_868_915(monkeypatch):
 
     assert radios_by_slot[2]["freq"] == "915M"
     assert radios_by_slot[2]["hop_interval"] == 0
+
+
+def test_single_sdr_mode_us_uses_secondary_band(monkeypatch):
+    # Issue #103: one dongle + rtl_single_sdr_mode=us should run the 900 MHz
+    # secondary band plan instead of the 433 MHz primary default.
+    detected = [{"index": 0, "id": "00000001", "name": "RTL_00000001"}]
+
+    _setup_main_for_test(monkeypatch, detected_devices=detected, country_code="US")
+    monkeypatch.setattr(main_mod.config, "RTL_SINGLE_SDR_MODE", "us")
+
+    main_mod.main()
+
+    threads = _rtl_threads()
+    assert len(threads) == 1
+
+    r = threads[0].args[0]
+    assert r["slot"] == 0
+    assert r["freq"] == "915M"
+    assert r["rate"] == "1024k"
+    assert r["hop_interval"] == 0
+    # device fields are preserved
+    assert r["id"] == "00000001"
+    assert r["index"] == 0
+
+
+def test_single_sdr_mode_world_hops_both_bands(monkeypatch):
+    # world plan -> hop 868M,915M with a positive hop interval.
+    detected = [{"index": 0, "id": "00000001", "name": "RTL_00000001"}]
+
+    _setup_main_for_test(monkeypatch, detected_devices=detected, country_code=None)
+    monkeypatch.setattr(main_mod.config, "RTL_SINGLE_SDR_MODE", "world")
+
+    main_mod.main()
+
+    threads = _rtl_threads()
+    assert len(threads) == 1
+
+    r = threads[0].args[0]
+    assert r["freq"] == "868M,915M"
+    assert r["hop_interval"] > 0
+
+
+def test_single_sdr_mode_off_keeps_primary_default(monkeypatch):
+    # Default/off -> legacy behavior: solo dongle stays on the 433 MHz primary.
+    detected = [{"index": 0, "id": "00000001", "name": "RTL_00000001"}]
+
+    _setup_main_for_test(monkeypatch, detected_devices=detected, country_code="US")
+    monkeypatch.setattr(main_mod.config, "RTL_SINGLE_SDR_MODE", "off")
+
+    main_mod.main()
+
+    threads = _rtl_threads()
+    assert len(threads) == 1
+
+    r = threads[0].args[0]
+    assert r["freq"] == "433.92M"
+    assert r["rate"] == "250k"
 
 


### PR DESCRIPTION
## Summary

Fixes #103.

With a single RTL-SDR, auto mode starts it as **Radio #1 (433.92 MHz primary)**, so the **900 MHz secondary band plan** used for utility/water/gas meters is unreachable without a second dongle.

This adds **`rtl_single_sdr_mode`** (Option B from the issue): a flag that makes a solo dongle adopt the **secondary band-plan behavior** instead of the primary default.

- `off` (default) — legacy behavior, solo dongle stays on `rtl_default_freq` (433.92 MHz)
- `auto` — infer the high band from HA country (else hop 868/915)
- `us` → `915M`
- `eu` → `868M`
- `world` → hop `868M,915M`

It reuses the existing `choose_secondary_band_defaults()` (the exact logic Radio #2 uses in auto multi-mode) and honors `rtl_auto_secondary_freq` / `rtl_auto_secondary_rate`. Default `off` keeps all existing single-dongle setups unchanged.

## Changes

- `config.py` — new `rtl_single_sdr_mode` setting + export
- `config.yaml` — add-on option default + schema (`list(off|auto|us|eu|world)`)
- `main.py` — single-dongle branch: when enabled, build the radio from the secondary band plan
- `README.md` / `CHANGELOG.md` — docs
- `tests/test_main_auto_multi_plan.py` — new tests: `us` → 915M (no hop), `world` → 868M,915M (hops), `off` → 433.92M (legacy)

## Testing

`pytest tests/test_main_auto_multi_plan.py` and the band-plan/util/commandline suites pass. The single-dongle branch is exercised via the existing `FakeThread`/detection harness; no behavior change when `rtl_single_sdr_mode` is `off`.
